### PR TITLE
Fix unused React import in build

### DIFF
--- a/src/pages/SharedDiet.tsx
+++ b/src/pages/SharedDiet.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import {
   Box,


### PR DESCRIPTION
Remove unused `React` import from `SharedDiet.tsx` to fix TS6133 build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae61af11-cbfc-4c44-bcef-b9a9a25be8a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae61af11-cbfc-4c44-bcef-b9a9a25be8a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>